### PR TITLE
Remove UTF-8 BOM from Persian localisation files

### DIFF
--- a/localisation/english/PER_Focus_l_english.yml
+++ b/localisation/english/PER_Focus_l_english.yml
@@ -1,4 +1,4 @@
-﻿l_english:
+l_english:
   PER_initiate_early_efforts:0 "Initiate Early Efforts"
   PER_initiate_early_efforts_desc:0 "Commence a rigorously planned program of industrial modernization and scientific inquiry to lay the foundation for our nation’s future progress."
 

--- a/localisation/english/PER_events_l_english.yml
+++ b/localisation/english/PER_events_l_english.yml
@@ -1,4 +1,4 @@
-﻿l_english:
+l_english:
  PER_hijab.1.t: "The Veil Debate"
  PER_hijab.1.d: "For centuries, the veil has been part of our cultural and religious fabric. But as Iran marches toward modernity, the role of hijab in public life is being fiercely debated. Reformists call for complete removal, traditionalists demand full enforcement, and moderates seek a middle ground. The decision we make today will shape the soul of our nation — are we to embrace modern ideals, preserve tradition, or find balance?"
 

--- a/localisation/english/PER_ideas_l_english.yml
+++ b/localisation/english/PER_ideas_l_english.yml
@@ -1,4 +1,4 @@
-﻿l_english:
+l_english:
  PER_hijab_banned: "Unveiling Order"
  PER_hijab_banned_desc: "Traditional veils are prohibited in public. This policy enforces visual uniformity, strengthens state authority, and eliminates attire that disrupts national cohesion."
 


### PR DESCRIPTION
## Summary
- clean UTF-8 BOM from Persian localisation files

## Testing
- `grep -al $'\xEF\xBB\xBF' localisation/english/*`

------
https://chatgpt.com/codex/tasks/task_e_6842e8b0b1ec83318f369a8dce6fb6f7